### PR TITLE
Fix usage of $GOPATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_IMAGE_NAME ?= thanos
 DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short HEAD)
 
 TMP_GOPATH        ?= /tmp/thanos-go
-GOBIN             ?= ${GOPATH}/bin
+GOBIN             ?= $(firstword $(subst :, ,$GOPATH))/bin
 GO111MODULE       ?= on
 export GO111MODULE
 GOPROXY           ?= https://proxy.golang.org


### PR DESCRIPTION
The command `make build` fails when `$GOPATH` contains multiple paths separated by `:`:

Example:

```
$ echo $GOPATH
/go:/opt/rh/go-toolset/root/usr/share/gocode

$ make build
Makefile:99: *** target pattern contains no `%'.  Stop.
```