### PR TITLE
*: Disable goproxy for downstream builds

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,6 +3,7 @@ WORKDIR /go/src/github.com/improbable-eng/thanos
 COPY . .
 ENV GOFLAGS="-mod=vendor"
 ENV GO111MODULE=on
+ENV GOPROXY=direct
 RUN if yum install -y prometheus-promu; then export PROMU=/usr/bin/promu; fi && make build
 
 FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base


### PR DESCRIPTION
Disabling goproxy should improve reliability of downstream build pipeline.

Spawned by problems in https://github.com/openshift/thanos/pull/5
Possibly related to https://github.com/golang/go/issues/33513

/cc @LiliC @s-urbaniak