### PR TITLE
do not run "go mod tidy" on every build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ assets: $(GOBINDATA)
 
 # build builds Thanos binary using `promu`.
 .PHONY: build
-build: check-git  go-mod-tidy $(PROMU)
+build: check-git $(PROMU)
 	@echo ">> building binaries $(GOBIN)"
 	@$(PROMU) build --prefix $(PREFIX)
 


### PR DESCRIPTION
Running `go mod tidy` prevents builds in OSBS.

/cc @s-urbaniak 