### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -15,8 +15,8 @@ FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 LABEL io.k8s.display-name="OpenShift Thanos" \
       io.k8s.description="Highly available Prometheus setup with long term storage capabilities." \
       io.openshift.tags="prometheus,monitoring" \
-      maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
-      version="v0.6.0"
+      summary="Highly available Prometheus setup with long term storage capabilities." \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
 
 COPY --from=builder /go/src/github.com/improbable-eng/thanos/thanos /bin/thanos
 


### PR DESCRIPTION
- Removing `version` label as it is not needed and easily goes stale
- Fixing `maintainer` label to end with `@redhat.com` as this is expected
- Overriding `summary` label as it is inherited from base image and results with incorrect value

/cc @openshift/openshift-team-monitoring 