### PR TITLE
Bug 1870287: pkg/query: eventually update rules client

### DIFF
--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -249,7 +249,7 @@ type storeRef struct {
 	logger log.Logger
 }
 
-func (s *storeRef) Update(labelSets []storepb.LabelSet, minTime int64, maxTime int64, storeType component.StoreAPI) {
+func (s *storeRef) Update(labelSets []storepb.LabelSet, minTime int64, maxTime int64, storeType component.StoreAPI, rule rulespb.RulesClient) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -257,6 +257,7 @@ func (s *storeRef) Update(labelSets []storepb.LabelSet, minTime int64, maxTime i
 	s.labelSets = labelSets
 	s.minTime = minTime
 	s.maxTime = maxTime
+	s.rule = rule
 }
 
 func (s *storeRef) StoreType() component.StoreAPI {
@@ -467,12 +468,13 @@ func (s *StoreSet) getActiveStores(ctx context.Context, stores map[string]*store
 					level.Warn(s.logger).Log("msg", "update of store node failed", "err", errors.Wrap(err, "dialing connection"), "address", addr)
 					return
 				}
-				var rule rulespb.RulesClient
-				if _, ok := ruleAddrSet[addr]; ok {
-					rule = rulespb.NewRulesClient(conn)
-				}
 
-				st = &storeRef{StoreClient: storepb.NewStoreClient(conn), storeType: component.UnknownStoreAPI, rule: rule, cc: conn, addr: addr, logger: s.logger}
+				st = &storeRef{StoreClient: storepb.NewStoreClient(conn), storeType: component.UnknownStoreAPI, cc: conn, addr: addr, logger: s.logger}
+			}
+
+			var rule rulespb.RulesClient
+			if _, ok := ruleAddrSet[addr]; ok {
+				rule = rulespb.NewRulesClient(st.cc)
 			}
 
 			// Check existing or new store. Is it healthy? What are current metadata?
@@ -499,7 +501,7 @@ func (s *StoreSet) getActiveStores(ctx context.Context, stores map[string]*store
 			}
 
 			s.updateStoreStatus(st, nil)
-			st.Update(labelSets, minTime, maxTime, storeType)
+			st.Update(labelSets, minTime, maxTime, storeType, rule)
 
 			mtx.Lock()
 			defer mtx.Unlock()

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -781,6 +781,196 @@ func TestStoreSet_Update_Rules(t *testing.T) {
 	}
 }
 
+func TestStoreSet_Rules_Discovery(t *testing.T) {
+	stores, err := startTestStores([]testStoreMeta{
+		{
+			extlsetFn: func(addr string) []storepb.LabelSet {
+				return []storepb.LabelSet{}
+			},
+			storeType: component.Sidecar,
+		},
+		{
+			extlsetFn: func(addr string) []storepb.LabelSet {
+				return []storepb.LabelSet{}
+			},
+			storeType: component.Rule,
+		},
+	})
+	testutil.Ok(t, err)
+	defer stores.Close()
+
+	type discoveryState struct {
+		name           string
+		storeSpecs     func() []StoreSpec
+		ruleSpecs      func() []RuleSpec
+		expectedStores int
+		expectedRules  int
+	}
+
+	for _, tc := range []struct {
+		states []discoveryState
+		name   string
+	}{
+		{
+			name: "StoreAPI and RulesAPI concurrent discovery",
+			states: []discoveryState{
+				{
+					name:           "no stores",
+					storeSpecs:     nil,
+					ruleSpecs:      nil,
+					expectedRules:  0,
+					expectedStores: 0,
+				},
+				{
+					name: "RulesAPI discovered",
+					storeSpecs: func() []StoreSpec {
+						return []StoreSpec{
+							NewGRPCStoreSpec(stores.orderAddrs[0], false),
+						}
+					},
+					ruleSpecs: func() []RuleSpec {
+						return []RuleSpec{
+							NewGRPCStoreSpec(stores.orderAddrs[0], false),
+						}
+					},
+					expectedRules:  1,
+					expectedStores: 1,
+				},
+			},
+		},
+
+		{
+			name: "StoreAPI discovery first, eventually discovered RulesAPI",
+			states: []discoveryState{
+				{
+					name:           "no stores",
+					storeSpecs:     nil,
+					ruleSpecs:      nil,
+					expectedRules:  0,
+					expectedStores: 0,
+				},
+				{
+					name: "StoreAPI discovered, no RulesAPI discovered",
+					storeSpecs: func() []StoreSpec {
+						return []StoreSpec{
+							NewGRPCStoreSpec(stores.orderAddrs[0], false),
+						}
+					},
+					expectedStores: 1,
+					expectedRules:  0,
+				},
+				{
+					name: "RulesAPI discovered",
+					storeSpecs: func() []StoreSpec {
+						return []StoreSpec{
+							NewGRPCStoreSpec(stores.orderAddrs[0], false),
+						}
+					},
+					ruleSpecs: func() []RuleSpec {
+						return []RuleSpec{
+							NewGRPCStoreSpec(stores.orderAddrs[0], false),
+						}
+					},
+					expectedStores: 1,
+					expectedRules:  1,
+				},
+			},
+		},
+
+		{
+			name: "RulesAPI discovery first, eventually discovered StoreAPI",
+			states: []discoveryState{
+				{
+					name:           "no stores",
+					storeSpecs:     nil,
+					ruleSpecs:      nil,
+					expectedRules:  0,
+					expectedStores: 0,
+				},
+				{
+					name:       "RulesAPI discovered, no StoreAPI discovered",
+					storeSpecs: nil,
+					ruleSpecs: func() []RuleSpec {
+						return []RuleSpec{
+							NewGRPCStoreSpec(stores.orderAddrs[0], false),
+						}
+					},
+					expectedStores: 0,
+					expectedRules:  0,
+				},
+				{
+					name: "StoreAPI discovered",
+					storeSpecs: func() []StoreSpec {
+						return []StoreSpec{
+							NewGRPCStoreSpec(stores.orderAddrs[0], false),
+						}
+					},
+					ruleSpecs: func() []RuleSpec {
+						return []RuleSpec{
+							NewGRPCStoreSpec(stores.orderAddrs[0], false),
+						}
+					},
+					expectedStores: 1,
+					expectedRules:  1,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			currentState := 0
+
+			storeSet := NewStoreSet(nil, nil,
+				func() []StoreSpec {
+					if tc.states[currentState].storeSpecs == nil {
+						return nil
+					}
+
+					return tc.states[currentState].storeSpecs()
+				},
+				func() []RuleSpec {
+					if tc.states[currentState].ruleSpecs == nil {
+						return nil
+					}
+
+					return tc.states[currentState].ruleSpecs()
+				},
+				testGRPCOpts, time.Minute)
+
+			defer storeSet.Close()
+
+			for {
+				storeSet.Update(context.Background())
+				testutil.Equals(
+					t,
+					tc.states[currentState].expectedStores,
+					len(storeSet.stores),
+					"unexepected discovered stores in state %q",
+					tc.states[currentState].name,
+				)
+
+				gotRules := 0
+				for _, ref := range storeSet.stores {
+					if ref.HasRulesAPI() {
+						gotRules += 1
+					}
+				}
+				testutil.Equals(
+					t,
+					tc.states[currentState].expectedRules,
+					gotRules,
+					"unexpected discovered rules in state %q",
+					tc.states[currentState].name,
+				)
+
+				currentState = currentState + 1
+				if len(tc.states) == currentState {
+					break
+				}
+			}
+		})
+	}
+}
+
 type errThatMarshalsToEmptyDict struct {
 	msg string
 }


### PR DESCRIPTION
This is a backport of https://github.com/thanos-io/thanos/pull/3280.

/cc @openshift/openshift-team-monitoring 