### PR TITLE
Updating thanos builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/improbable-eng/thanos
 COPY . .
 ENV GOFLAGS="-mod=vendor"
@@ -11,7 +11,7 @@ RUN if ! yum install -y prometheus-promu; then \
         curl -s -L https://github.com/prometheus/promu/releases/download/v0.5.0/promu-0.5.0.linux-amd64.tar.gz | tar -xzvf - -C /usr/bin  --strip-components 1 promu-0.5.0.linux-amd64/promu; \
     fi; \
     promu build;
-FROM  registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 LABEL io.k8s.display-name="OpenShift Thanos" \
       io.k8s.description="Highly available Prometheus setup with long term storage capabilities." \
       io.openshift.tags="prometheus,monitoring" \


### PR DESCRIPTION
Updating thanos builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/thanos.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.