### PR TITLE
Bug 1897252: CARRY: cmd/thanos: fix DNS resolution when ctx is canceled 

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -388,12 +388,12 @@ func runQuery(
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
 			return runutil.Repeat(dnsSDInterval, ctx.Done(), func() error {
-				ctx, cancel = context.WithTimeout(ctx, dnsSDInterval)
-				defer cancel()
-				if err := dnsStoreProvider.Resolve(ctx, append(fileSDCache.Addresses(), storeAddrs...)); err != nil {
+				resolveCtx, resolveCancel := context.WithTimeout(ctx, dnsSDInterval)
+				defer resolveCancel()
+				if err := dnsStoreProvider.Resolve(resolveCtx, append(fileSDCache.Addresses(), storeAddrs...)); err != nil {
 					level.Error(logger).Log("msg", "failed to resolve addresses for storeAPIs", "err", err)
 				}
-				if err := dnsRuleProvider.Resolve(ctx, ruleAddrs); err != nil {
+				if err := dnsRuleProvider.Resolve(resolveCtx, ruleAddrs); err != nil {
 					level.Error(logger).Log("msg", "failed to resolve addresses for rulesAPIs", "err", err)
 				}
 				return nil


### PR DESCRIPTION
Cherry-pick of https://github.com/thanos-io/thanos/pull/3524 which is a follow-up fix for https://github.com/thanos-io/thanos/pull/3508 (downstream: https://github.com/openshift/thanos/pull/41).
cc @lilic @s-urbaniak 