### PR TITLE
Bug 1994120: Do not ignore vendor/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 /prometheus
 /thanos
-/vendor/
 /mixin/vendor/
 node_modules/
 


### PR DESCRIPTION
Since a recent imagebuilder deployment, .dockerignore is not ignored
anymore. Since then, `/vendor/` is not available in the build. This
commit ensures that dependencies are available in the build environment.