### PR TITLE
Bug 2071479: Thanos Querier high CPU and memory usage till OOM

### DIFF
--- a/pkg/exemplars/proxy.go
+++ b/pkg/exemplars/proxy.go
@@ -191,8 +191,8 @@ func (stream *exemplarsStream) receive(ctx context.Context) error {
 			if err := stream.server.Send(exemplarspb.NewWarningExemplarsResponse(err)); err != nil {
 				return errors.Wrapf(err, "sending exemplars error to server %v", stream.server)
 			}
-
-			continue
+			// Not an error if response strategy is warning.
+			return nil
 		}
 
 		if w := exemplar.GetWarning(); w != "" {

--- a/pkg/metadata/proxy.go
+++ b/pkg/metadata/proxy.go
@@ -135,7 +135,8 @@ func (stream *metricMetadataStream) receive(ctx context.Context) error {
 				return errors.Wrapf(err, "sending metadata error to server %v", stream.server)
 			}
 
-			continue
+			// Not an error if response strategy is warning.
+			return nil
 		}
 
 		if w := resp.GetWarning(); w != "" {

--- a/pkg/targets/proxy.go
+++ b/pkg/targets/proxy.go
@@ -119,8 +119,8 @@ func (stream *targetsStream) receive(ctx context.Context) error {
 			if err := stream.server.Send(targetspb.NewWarningTargetsResponse(err)); err != nil {
 				return errors.Wrapf(err, "sending targets error to server %v", stream.server)
 			}
-
-			continue
+			// Not an error if response strategy is warning.
+			return nil
 		}
 
 		if w := target.GetWarning(); w != "" {


### PR DESCRIPTION
This cherry-picks upstream patch that fixes the bug

Query: Fix (*exemplarsStream).receive/(*metricMetadataStream).receive/(*targetsStreamStream).receive
  infinite loop when target response Unimplemented error (#4676) (#4681)

See:
  - https://github.com/thanos-io/thanos/issues/4676#issuecomment-922413448
  - https://github.com/thanos-io/thanos/pull/4681

Signed-off-by: hanjm <hanjinming@outlook.com>
(cherry picked from commit 2d4d140d7af63ad77ecf8ac1e76cae46e0a64368)

Signed-off-by: Sunil Thaha <3005132+sthaha@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Applies an upstream patch that fixes OOM

## Verification

<!-- How you tested it? How do you know it works? -->
The same test procedure as in [in https://bugzilla.redhat.com/show_bug.cgi?id=2055305#](https://bugzilla.redhat.com/show_bug.cgi?id=2055305#c24)
