### PR TITLE
OCPBUGS-52945: Update Go version in go.mod to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thanos-io/thanos
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.40.0 // indirect


### PR DESCRIPTION
This commit modifies the go.mod file to explicitly use go version
1.22.0. This is done in order to avoid konflux build issues when using
hermetic builds related to failure finding the toolchain.

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

