### PR TITLE
OCPBUGS-80515: Bump google.golang.org/grpc to v1.79.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	golang.org/x/time v0.7.0
 	google.golang.org/api v0.195.0 // indirect
 	google.golang.org/genproto v0.0.0-20240823204242-4ba0660f739c // indirect
-	google.golang.org/grpc v1.66.0
+	google.golang.org/grpc v1.79.3
 	google.golang.org/grpc/examples v0.0.0-20211119005141-f45e61797429
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.4.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1554,7 +1554,7 @@ google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/googleapis/rpc/code
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.66.0 => google.golang.org/grpc v1.63.2
+# google.golang.org/grpc v1.79.3 => google.golang.org/grpc v1.63.2
 ## explicit; go 1.19
 google.golang.org/grpc
 google.golang.org/grpc/attributes


### PR DESCRIPTION
This PR is part of an automated process.

The commands used to generate this PR were:

```
go get google.golang.org/grpc@v1.79.3 toolchain@none
go mod tidy
go mod vendor
```

A member of the Red Hat Openshift Sustaining Team will review the PR and take appropriate action.