### PR TITLE
OCPBUGS-80693: Bump google.golang.org/grpc to v1.79.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	golang.org/x/sync v0.15.0
 	golang.org/x/text v0.26.0
 	golang.org/x/time v0.12.0
-	google.golang.org/grpc v1.73.0
+	google.golang.org/grpc v1.79.3
 	google.golang.org/grpc/examples v0.0.0-20211119005141-f45e61797429
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/yaml.v2 v2.4.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1687,7 +1687,7 @@ google.golang.org/genproto/googleapis/api/monitoredres
 google.golang.org/genproto/googleapis/rpc/code
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.73.0 => google.golang.org/grpc v1.63.2
+# google.golang.org/grpc v1.79.3 => google.golang.org/grpc v1.63.2
 ## explicit; go 1.19
 google.golang.org/grpc
 google.golang.org/grpc/attributes


### PR DESCRIPTION
Modules affected: .

The commands used to generate this PR were:

go get google.golang.org/grpc@v1.79.3
go mod tidy
go mod vendor
A member of the Red Hat Openshift Sustaining Team will review the PR and take appropriate action.