### PR TITLE
NO-JIRA: chore: revert narrow selectors detection for le/quantile labels

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -25,12 +25,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/common/version"
-	"github.com/prometheus/prometheus/promql/parser"
 	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/thanos-io/thanos/pkg/extkingpin"
 	"github.com/thanos-io/thanos/pkg/logging"
-	"github.com/thanos-io/thanos/pkg/logutil"
 	"github.com/thanos-io/thanos/pkg/tracing/client"
 )
 
@@ -68,9 +66,6 @@ func main() {
 	cmd, setup := app.Parse()
 	logger := logging.NewLogger(*logLevel, *logFormat, *debugName)
 
-	// Hacky but temporary
-	parser.Logger = logutil.GoKitLogToSlog(log.With(logger, "component", "prometheus-parser"))
-
 	limits, err := configureGoAutoMemLimit(goMemLimitConf)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to configure Go runtime memory limits", "err", err)
@@ -100,9 +95,6 @@ func main() {
 		),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
-
-	// Hacky but temporary
-	metrics.MustRegister(parser.NarrowSelectors)
 
 	// Some packages still use default Register. Replace to have those metrics.
 	prometheus.DefaultRegisterer = metrics

--- a/go.mod
+++ b/go.mod
@@ -318,10 +318,6 @@ replace (
 	// Required by Cortex https://github.com/cortexproject/cortex/pull/3051.
 	github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 
-	// Based on github.com/prometheus/prometheus v0.308.0 used in Thanos v0.41.0
-	// Using the extra check in Prometheus parser to help identify "le"/"quantile" selectors misuses in Prometheus v3.
-	github.com/prometheus/prometheus => github.com/machine424/prometheus v0.0.0-20260312223754-be691e93d050
-
 	// Pin kuberesolver/v5 to support new grpc version. Need to upgrade kuberesolver version on weaveworks/common.
 	github.com/sercand/kuberesolver/v4 => github.com/sercand/kuberesolver/v5 v5.1.1
 

--- a/go.sum
+++ b/go.sum
@@ -3519,8 +3519,6 @@ github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuz
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
-github.com/machine424/prometheus v0.0.0-20260312223754-be691e93d050 h1:dPXDm1iEQ38rarxifyHYCSgSoIWPhRv99r5JzxxuY7A=
-github.com/machine424/prometheus v0.0.0-20260312223754-be691e93d050/go.mod h1:xXYKzScyqyFHihpS0UsXpC2F3RA/CygOs7wb4mpdusE=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
@@ -3787,6 +3785,8 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/prometheus/procfs v0.16.0/go.mod h1:8veyXUu3nGP7oaCxhX6yeaM5u4stL2FeMXnCqhDthZg=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/prometheus/prometheus v0.308.0 h1:kVh/5m1n6m4cSK9HYTDEbMxzuzCWyEdPdKSxFRxXj04=
+github.com/prometheus/prometheus v0.308.0/go.mod h1:xXYKzScyqyFHihpS0UsXpC2F3RA/CygOs7wb4mpdusE=
 github.com/prometheus/sigv4 v0.3.0 h1:QIG7nTbu0JTnNidGI1Uwl5AGVIChWUACxn2B/BQ1kms=
 github.com/prometheus/sigv4 v0.3.0/go.mod h1:fKtFYDus2M43CWKMNtGvFNHGXnAJJEGZbiYCmVp/F8I=
 github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=

--- a/vendor/github.com/prometheus/prometheus/promql/parser/parse.go
+++ b/vendor/github.com/prometheus/prometheus/promql/parser/parse.go
@@ -24,9 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/common/promslog"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -34,89 +32,6 @@ import (
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/util/strutil"
 )
-
-var (
-	// Logger will be initialized on Thanos side.
-	Logger          = promslog.NewNopLogger()
-	NarrowSelectors = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "prometheus_narrow_selectors_count",
-			Help: "Number of selectors that may unintentionally only match integers on 'quantile' and 'le' labels",
-		},
-		[]string{"component"},
-	)
-)
-
-// isInteger is a light strconv.Atoi that avoids allocations due to Atoi's returned error and doesn't
-// consider as integers invalid, big, or underscored integers.
-func isInteger(s string) (int, bool) {
-	sLen := len(s)
-	if strconv.IntSize == 32 && (0 < sLen && sLen < 10) ||
-		strconv.IntSize == 64 && (0 < sLen && sLen < 19) {
-		// Fast path for small integers that fit int type.
-		s0 := s
-		if s[0] == '-' || s[0] == '+' {
-			s = s[1:]
-			if len(s) < 1 {
-				return 0, false
-			}
-		}
-
-		n := 0
-		for _, ch := range []byte(s) {
-			ch -= '0'
-			if ch > 9 {
-				return 0, false
-			}
-			n = n*10 + int(ch)
-		}
-		if s0[0] == '-' {
-			n = -n
-		}
-		return n, true
-	}
-
-	// Slow path for invalid, big, or underscored integers.
-	i64, err := strconv.ParseInt(s, 10, 0)
-	return int(i64), err == nil
-}
-
-// checkLabelMatchers helps to detect unintentional misuses of matchers on "quantile" and "le" labels after normalization during scraping
-// introduced in Prometheus3. For more details, see https://prometheus.io/docs/prometheus/latest/migration/#le-and-quantile-label-values.
-// It specifically detects integers-only label matchers formatted as "integer" and "integer|integer|integer" (as they're the most likely to contain them).
-// Refer to Test_checkLabelMatchers for more details.
-func checkLabelMatchers(vs *VectorSelector) {
-Outer:
-	for _, lm := range vs.LabelMatchers {
-		if lm == nil {
-			continue
-		}
-		if lm.Name == model.QuantileLabel || (strings.HasSuffix(vs.Name, "_bucket") && lm.Name == model.BucketLabel) {
-			switch lm.Type {
-			case labels.MatchEqual, labels.MatchNotEqual:
-				if _, ok := isInteger(lm.Value); ok {
-					NarrowSelectors.WithLabelValues("prometheus-parser").Inc()
-					Logger.Debug("selector set to explicitly match an integer, but values could be floats", "narrow_matcher_label", lm.Name, "integer", lm.Value, "matchers", fmt.Sprintf("%v", vs.LabelMatchers))
-				}
-				break Outer
-			case labels.MatchRegexp, labels.MatchNotRegexp:
-				if len(lm.Value) == 0 {
-					break Outer
-				}
-				vals := strings.Split(lm.Value, "|")
-				for _, val := range vals {
-					if _, ok := isInteger(val); !ok {
-						break Outer
-					}
-				}
-
-				NarrowSelectors.WithLabelValues("prometheus-parser").Inc()
-				Logger.Debug("selector set to explicitly match integers only, but values could be floats", "narrow_matcher_label", lm.Name, "matchers", fmt.Sprintf("%v", vs.LabelMatchers))
-				break Outer
-			}
-		}
-	}
-}
 
 var parserPool = sync.Pool{
 	New: func() any {
@@ -290,7 +205,6 @@ func ParseMetricSelector(input string) (m []*labels.Matcher, err error) {
 
 	parseResult := p.parseGenerated(START_METRIC_SELECTOR)
 	if parseResult != nil {
-		checkLabelMatchers(parseResult.(*VectorSelector))
 		m = parseResult.(*VectorSelector).LabelMatchers
 	}
 
@@ -942,8 +856,6 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 					p.addParseErrf(n.PositionRange(), "metric name must not be set twice: %q or %q", n.Name, m.Value)
 				}
 			}
-
-			checkLabelMatchers(n)
 
 			// Skip the check for non-empty matchers because an explicit
 			// metric name is a non-empty matcher.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1069,7 +1069,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v0.308.0 => github.com/machine424/prometheus v0.0.0-20260312223754-be691e93d050
+# github.com/prometheus/prometheus v0.308.0
 ## explicit; go 1.24.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1995,7 +1995,6 @@ zenhack.net/go/util/deferred
 zenhack.net/go/util/sync/mutex
 # capnproto.org/go/capnp/v3 => capnproto.org/go/capnp/v3 v3.0.0-alpha.30
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
-# github.com/prometheus/prometheus => github.com/machine424/prometheus v0.0.0-20260312223754-be691e93d050
 # github.com/sercand/kuberesolver/v4 => github.com/sercand/kuberesolver/v5 v5.1.1
 # github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 # google.golang.org/grpc => github.com/thanos-community/grpc-go v0.0.0-20260331083222-a7315f1dfb76


### PR DESCRIPTION
No longer needed for OCP 5.0

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
